### PR TITLE
add a base-message slot to shlex-error condition

### DIFF
--- a/shlex.lisp
+++ b/shlex.lisp
@@ -31,21 +31,24 @@
   (:documentation "Return the next token."))
 
 (define-condition shlex-error (error)
-  ((lexer :initarg :lexer)))
+  ((lexer :initarg :lexer)
+   (base-message :accessor base-message)))
 
 (define-condition no-closing-quotation (shlex-error)
-  ()
+  ((base-message :initform "Missing closing quotation in string"))
   (:report (lambda (c s)
-             (with-slots (lexer) c
-               (format s "Missing closing quotation in string (line ~d):~%~a"
+             (with-slots (base-message lexer) c
+               (format s "~a (line ~d):~%~a"
+                       (base-message c)
                        (lexer-line-number lexer)
                        (lexer-input lexer))))))
 
 (define-condition no-escaped-character (shlex-error)
-  ()
+  ((base-message :initform "No escaped character in string"))
   (:report (lambda (c s)
-             (with-slots (lexer) c
-               (format s "No escaped character in string (line ~d):~%~a"
+             (with-slots (base-message lexer) c
+               (format s "~a (line ~d):~%~a"
+                       (base-message c)
                        (lexer-line-number lexer)
                        (lexer-input lexer))))))
 


### PR DESCRIPTION
Hi,

I use this lib (kuddos! very helpful) to parse a simple, one-liner user input. I figured he doesn't need a redundant line and line number, hence this small addition.

```
Missing closing quotation in string (line 1):
 server "127
```

to just

```
Missing closing quotation in string
```

actually I could remove the "in string" on my side, but it seems significant for shlex.

Regards